### PR TITLE
Use HexBytes without custom Marshal/UnmarshalJSON functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,5 +132,4 @@ replace (
 	// the following version across all dependencies.
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
-
 )

--- a/proto/cosmwasm/wasm/v1/types.proto
+++ b/proto/cosmwasm/wasm/v1/types.proto
@@ -131,8 +131,7 @@ message AbsoluteTxPosition {
 // Model is a struct that holds a KV pair
 message Model {
   // hex-encode key to read it better (this is often ascii)
-  bytes key = 1 [ (gogoproto.casttype) =
-                      "github.com/tendermint/tendermint/libs/bytes.HexBytes" ];
+  bytes key = 1 [ (gogoproto.casttype) = "HexBytes" ];
   // base64-encode raw value
   bytes value = 2;
 }

--- a/x/wasm/keeper/test_fuzz.go
+++ b/x/wasm/keeper/test_fuzz.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	fuzz "github.com/google/gofuzz"
-	tmBytes "github.com/tendermint/tendermint/libs/bytes"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
@@ -50,9 +49,9 @@ func FuzzContractCodeHistory(m *types.ContractCodeHistoryEntry, c fuzz.Continue)
 }
 
 func FuzzStateModel(m *types.Model, c fuzz.Continue) {
-	m.Key = tmBytes.HexBytes(c.RandString())
+	m.Key = types.HexBytes(c.RandString())
 	if len(m.Key) == 0 {
-		m.Key = tmBytes.HexBytes("non empty key")
+		m.Key = types.HexBytes("non empty key")
 	}
 	c.Fuzz(&m.Value)
 }

--- a/x/wasm/types/bytes.go
+++ b/x/wasm/types/bytes.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -19,32 +18,6 @@ func (bz HexBytes) Marshal() ([]byte, error) {
 // Unmarshal needed for protobuf compatibility
 func (bz *HexBytes) Unmarshal(data []byte) error {
 	*bz = data
-	return nil
-}
-
-// MarshalText encodes a HexBytes value as hexadecimal digits.
-// This method is used by json.Marshal.
-func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	enc := hex.EncodeToString([]byte(bz))
-	return []byte(strings.ToUpper(enc)), nil
-}
-
-// UnmarshalText handles decoding of HexBytes from JSON strings.
-// This method is used by json.Unmarshal.
-// It allows decoding of both hex and base64-encoded byte arrays.
-func (bz *HexBytes) UnmarshalJSON(data []byte) error {
-	input := string(data)
-	if input == "" || input == "null" {
-		return nil
-	}
-	dec, err := hex.DecodeString(input)
-	if err != nil {
-		dec, err = base64.StdEncoding.DecodeString(input)
-		if err != nil {
-			return err
-		}
-	}
-	*bz = HexBytes(dec)
 	return nil
 }
 

--- a/x/wasm/types/bytes.go
+++ b/x/wasm/types/bytes.go
@@ -24,7 +24,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 
 // MarshalText encodes a HexBytes value as hexadecimal digits.
 // This method is used by json.Marshal.
-func (bz HexBytes) MarshalText() ([]byte, error) {
+func (bz HexBytes) MarshalJSON() ([]byte, error) {
 	enc := hex.EncodeToString([]byte(bz))
 	return []byte(strings.ToUpper(enc)), nil
 }
@@ -32,7 +32,7 @@ func (bz HexBytes) MarshalText() ([]byte, error) {
 // UnmarshalText handles decoding of HexBytes from JSON strings.
 // This method is used by json.Unmarshal.
 // It allows decoding of both hex and base64-encoded byte arrays.
-func (bz *HexBytes) UnmarshalText(data []byte) error {
+func (bz *HexBytes) UnmarshalJSON(data []byte) error {
 	input := string(data)
 	if input == "" || input == "null" {
 		return nil
@@ -66,12 +66,4 @@ func (bz HexBytes) Format(s fmt.State, verb rune) {
 	default:
 		s.Write([]byte(fmt.Sprintf("%X", []byte(bz))))
 	}
-}
-
-func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	return bz.MarshalText()
-}
-
-func (bz *HexBytes) UnmarshalJSON(data []byte) error {
-	return bz.UnmarshalText(data)
 }

--- a/x/wasm/types/bytes.go
+++ b/x/wasm/types/bytes.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// HexBytes is a wrapper around []byte that encodes data as hexadecimal strings
+// for use in JSON.
+type HexBytes []byte
+
+// Marshal needed for protobuf compatibility
+func (bz HexBytes) Marshal() ([]byte, error) {
+	return bz, nil
+}
+
+// Unmarshal needed for protobuf compatibility
+func (bz *HexBytes) Unmarshal(data []byte) error {
+	*bz = data
+	return nil
+}
+
+// MarshalText encodes a HexBytes value as hexadecimal digits.
+// This method is used by json.Marshal.
+func (bz HexBytes) MarshalText() ([]byte, error) {
+	enc := hex.EncodeToString([]byte(bz))
+	return []byte(strings.ToUpper(enc)), nil
+}
+
+// UnmarshalText handles decoding of HexBytes from JSON strings.
+// This method is used by json.Unmarshal.
+// It allows decoding of both hex and base64-encoded byte arrays.
+func (bz *HexBytes) UnmarshalText(data []byte) error {
+	input := string(data)
+	if input == "" || input == "null" {
+		return nil
+	}
+	dec, err := hex.DecodeString(input)
+	if err != nil {
+		dec, err = base64.StdEncoding.DecodeString(input)
+		if err != nil {
+			return err
+		}
+	}
+	*bz = HexBytes(dec)
+	return nil
+}
+
+// Bytes fulfills various interfaces in light-client, etc...
+func (bz HexBytes) Bytes() []byte {
+	return bz
+}
+func (bz HexBytes) String() string {
+	return strings.ToUpper(hex.EncodeToString(bz))
+}
+
+// Format writes either address of 0th element in a slice in base 16 notation,
+// with leading 0x (%p), or casts HexBytes to bytes and writes as hexadecimal
+// string to s.
+func (bz HexBytes) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'p':
+		s.Write([]byte(fmt.Sprintf("%p", bz)))
+	default:
+		s.Write([]byte(fmt.Sprintf("%X", []byte(bz))))
+	}
+}
+
+func (bz HexBytes) MarshalJSON() ([]byte, error) {
+	return bz.MarshalText()
+}
+
+func (bz *HexBytes) UnmarshalJSON(data []byte) error {
+	return bz.UnmarshalText(data)
+}

--- a/x/wasm/types/types.pb.go
+++ b/x/wasm/types/types.pb.go
@@ -14,7 +14,6 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	_ "github.com/regen-network/cosmos-proto"
-	github_com_tendermint_tendermint_libs_bytes "github.com/tendermint/tendermint/libs/bytes"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -434,7 +433,7 @@ var xxx_messageInfo_AbsoluteTxPosition proto.InternalMessageInfo
 // Model is a struct that holds a KV pair
 type Model struct {
 	// hex-encode key to read it better (this is often ascii)
-	Key github_com_tendermint_tendermint_libs_bytes.HexBytes `protobuf:"bytes,1,opt,name=key,proto3,casttype=github.com/tendermint/tendermint/libs/bytes.HexBytes" json:"key,omitempty"`
+	Key HexBytes `protobuf:"bytes,1,opt,name=key,proto3,casttype=HexBytes" json:"key,omitempty"`
 	// base64-encode raw value
 	Value []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 }


### PR DESCRIPTION
By using tendermint's HexBytes, the exported contract states cannot be properly imported. Switching back to default marshal/unmarshal behavior fixes it