### PR TITLE
execute contract metrics

### DIFF
--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"github.com/armon/go-metrics"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -83,6 +84,11 @@ func (m msgServer) ExecuteContract(goCtx context.Context, msg *types.MsgExecuteC
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "contract")
 	}
+	metrics.IncrCounterWithLabels(
+		[]string{"wasmd", "execute", "contract", "counter"},
+		1,
+		[]metrics.Label{{Name: "type", Value: contractAddr.String()}},
+	)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		sdk.EventTypeMessage,

--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"time"
 
 	"github.com/armon/go-metrics"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -84,9 +85,9 @@ func (m msgServer) ExecuteContract(goCtx context.Context, msg *types.MsgExecuteC
 	if err != nil {
 		return nil, sdkerrors.Wrap(err, "contract")
 	}
-	metrics.IncrCounterWithLabels(
-		[]string{"wasmd", "execute", "contract", "counter"},
-		1,
+	defer metrics.MeasureSinceWithLabels(
+		[]string{"wasmd", "execute", "contract", "latency"},
+		time.Now(),
 		[]metrics.Label{{Name: "contract", Value: contractAddr.String()}},
 	)
 

--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -87,7 +87,7 @@ func (m msgServer) ExecuteContract(goCtx context.Context, msg *types.MsgExecuteC
 	metrics.IncrCounterWithLabels(
 		[]string{"wasmd", "execute", "contract", "counter"},
 		1,
-		[]metrics.Label{{Name: "type", Value: contractAddr.String()}},
+		[]metrics.Label{{Name: "contract", Value: contractAddr.String()}},
 	)
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(


### PR DESCRIPTION
Adds a simple counter for the address that's executed 
![image](https://github.com/sei-protocol/sei-wasmd/assets/18161326/a839dad6-0f75-4f24-981a-dc16d00d039a)

