### PR TITLE
refactor tx position and update usages

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -32,6 +32,9 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, sdk.AnteDepGenerat
 	if options.SignModeHandler == nil {
 		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
 	}
+	if options.ParamsKeeper == nil {
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "params keeper is required for ante builder")
+	}
 	if options.WasmConfig == nil {
 		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "wasm config is required for ante builder")
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -317,7 +317,7 @@ func NewWasmApp(
 		feegrant.StoreKey, authzkeeper.StoreKey, wasm.StoreKey, icahosttypes.StoreKey, icacontrollertypes.StoreKey, intertxtypes.StoreKey,
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
-	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
+	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, banktypes.DeferredCacheStoreKey)
 
 	app := &WasmApp{
 		BaseApp:           bApp,
@@ -363,12 +363,13 @@ func NewWasmApp(
 		authtypes.ProtoBaseAccount,
 		maccPerms,
 	)
-	app.bankKeeper = bankkeeper.NewBaseKeeper(
+	app.bankKeeper = bankkeeper.NewBaseKeeperWithDeferredCache(
 		appCodec,
 		keys[banktypes.StoreKey],
 		app.accountKeeper,
 		app.getSubspace(banktypes.ModuleName),
 		app.ModuleAccountAddrs(),
+		memKeys[banktypes.DeferredCacheStoreKey],
 	)
 	app.authzKeeper = authzkeeper.NewKeeper(
 		keys[authzkeeper.StoreKey],
@@ -727,6 +728,7 @@ func NewWasmApp(
 				AccountKeeper:   app.accountKeeper,
 				BankKeeper:      app.bankKeeper,
 				FeegrantKeeper:  app.feeGrantKeeper,
+				ParamsKeeper:    app.paramsKeeper,
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/testutil"
+
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -144,12 +146,12 @@ func SetupWithGenesisValSet(t *testing.T, valSet *tmtypes.ValidatorSet, genAccs 
 
 	// commit genesis changes
 	app.Commit(context.Background())
-	app.BeginBlock(app.GetContextForDeliverTx([]byte{}), abci.RequestBeginBlock{Header: tmproto.Header{
+	app.FinalizeBlock(context.Background(), &abci.RequestFinalizeBlock{
 		Height:             app.LastBlockHeight() + 1,
-		AppHash:            app.LastCommitID().Hash,
+		Hash:               app.LastCommitID().Hash,
 		ValidatorsHash:     valSet.Hash(),
 		NextValidatorsHash: valSet.Hash(),
-	}})
+	})
 
 	return app
 }
@@ -438,12 +440,7 @@ func NewPubKeyFromHex(pk string) (res cryptotypes.PubKey) {
 }
 
 // EmptyBaseAppOptions is a stub implementing AppOptions
-type EmptyBaseAppOptions struct{}
-
-// Get implements AppOptions
-func (ao EmptyBaseAppOptions) Get(o string) interface{} {
-	return nil
-}
+type EmptyBaseAppOptions = testutil.TestAppOpts
 
 // FundAccount is a utility function that funds an account by minting and
 // sending the coins to the address. This should be used for testing purposes

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint v0.37.0-dev
 	github.com/tendermint/tm-db v0.6.8-0.20220519162814-e24b96538a12
+	go.opentelemetry.io/otel/sdk v1.9.0
 	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a
 	google.golang.org/grpc v1.50.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -123,7 +124,6 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/otel v1.9.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.9.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.9.0 // indirect
 	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/exp v0.0.0-20221026153819-32f3d567a233 // indirect
@@ -142,7 +142,7 @@ replace (
 	// Use the cosmos-flavored keyring library
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.53
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.2.64
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.7
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.2.53 h1:MSH00lb3ahioaOnJNC4yvMNNPuC9rC0kBZcY30ay5QI=
-github.com/sei-protocol/sei-cosmos v0.2.53/go.mod h1:XSmrSNlBQ7OQrk6VZMgARWsnD+1JSnQeDEZ7LEmexbo=
+github.com/sei-protocol/sei-cosmos v0.2.64 h1:h2vBtRvpL4D2+scy407RLPJzAHCHn2ZkdSxzo/RT6z8=
+github.com/sei-protocol/sei-cosmos v0.2.64/go.mod h1:retCl6F8SWQ8ookwdQXIGkK56AHSKNUN2X3u9nVzo7g=
 github.com/sei-protocol/sei-iavl v0.1.7 h1:cUdHDBkxs0FF/kOt1qCVLm0K+Bqaw92/dbZSgn4kxiA=
 github.com/sei-protocol/sei-iavl v0.1.7/go.mod h1:7PfkEVT5dcoQE+s/9KWdoXJ8VVVP1QpYYPLdxlkSXFk=
 github.com/sei-protocol/sei-ibc-go/v3 v3.1.0 h1:rFHk2R/3vbG9iNr7cYtVclW/UyEDSRFjNVPz60zZswU=

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -113,11 +113,14 @@ func MakeEncodingConfig(_ testing.TB) wasmappparams.EncodingConfig {
 }
 
 var TestingStakeParams = stakingtypes.Params{
-	UnbondingTime:     100,
-	MaxValidators:     10,
-	MaxEntries:        10,
-	HistoricalEntries: 10,
-	BondDenom:         "stake",
+	UnbondingTime:                      100,
+	MaxValidators:                      10,
+	MaxEntries:                         10,
+	HistoricalEntries:                  10,
+	MinCommissionRate:                  sdk.MustNewDecFromStr("0.05"),
+	MaxVotingPowerRatio:                sdk.MustNewDecFromStr("0.5"),
+	MaxVotingPowerEnforcementThreshold: sdk.NewInt(10000),
+	BondDenom:                          "stake",
 }
 
 type TestFaucet struct {

--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -128,10 +128,11 @@ func (c *ContractInfo) SetExtension(ext ContractInfoExtension) error {
 
 // ReadExtension copies the extension value to the pointer passed as argument so that there is no need to cast
 // For example with a custom extension of type `MyContractDetails` it will look as following:
-// 		var d MyContractDetails
-//		if err := info.ReadExtension(&d); err != nil {
-//			return nil, sdkerrors.Wrap(err, "extension")
-//		}
+//
+//	var d MyContractDetails
+//	if err := info.ReadExtension(&d); err != nil {
+//		return nil, sdkerrors.Wrap(err, "extension")
+//	}
 func (c *ContractInfo) ReadExtension(e ContractInfoExtension) error {
 	rv := reflect.ValueOf(e)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {
@@ -212,18 +213,14 @@ func (c *ContractInfo) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 // NewAbsoluteTxPosition gets a block position from the context
 func NewAbsoluteTxPosition(ctx sdk.Context) *AbsoluteTxPosition {
 	// we must safely handle nil gas meters
-	var index uint64
-	meter := ctx.BlockGasMeter()
-	if meter != nil {
-		index = meter.GasConsumed()
-	}
+	index := ctx.TxIndex()
 	height := ctx.BlockHeight()
 	if height < 0 {
 		panic(fmt.Sprintf("unsupported height: %d", height))
 	}
 	return &AbsoluteTxPosition{
 		BlockHeight: uint64(height),
-		TxIndex:     index,
+		TxIndex:     uint64(index),
 	}
 }
 


### PR DESCRIPTION
This refactors some of the calls and usages to make unit tests passing for the wasm keeper package, and also refactors the AbsoluteTxPosition to utilize the txindex instead of gas meter so that we can have consistency even when things are processed concurrently