### PR TITLE
WIP changes to fix runtime gas and add paramsKeeper to wasmKeeper for query gas multiplier

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -521,6 +521,7 @@ func NewWasmApp(
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],
+		app.paramsKeeper,
 		app.getSubspace(wasm.ModuleName),
 		app.accountKeeper,
 		app.bankKeeper,

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -669,7 +669,7 @@ func setupKeeper(t *testing.T) (*Keeper, sdk.Context, []sdk.StoreKey) {
 	wasmConfig := wasmTypes.DefaultWasmConfig()
 	pk := paramskeeper.NewKeeper(encodingConfig.Marshaler, encodingConfig.Amino, keyParams, tkeyParams)
 
-	srcKeeper := NewKeeper(encodingConfig.Marshaler, keyWasm, pk.Subspace(wasmTypes.ModuleName), authkeeper.AccountKeeper{}, nil, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, tempDir, wasmConfig, SupportedFeatures)
+	srcKeeper := NewKeeper(encodingConfig.Marshaler, keyWasm, paramskeeper.Keeper{}, pk.Subspace(wasmTypes.ModuleName), authkeeper.AccountKeeper{}, nil, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, tempDir, wasmConfig, SupportedFeatures)
 	return &srcKeeper, ctx, []sdk.StoreKey{keyWasm, keyParams}
 }
 

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -94,6 +94,7 @@ type Keeper struct {
 func NewKeeper(
 	cdc codec.Codec,
 	storeKey sdk.StoreKey,
+	paramsKeeper types.ParamsKeeper,
 	paramSpace paramtypes.Subspace,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
@@ -122,6 +123,7 @@ func NewKeeper(
 	keeper := &Keeper{
 		storeKey:          storeKey,
 		cdc:               cdc,
+		paramsKeeper:      paramsKeeper,
 		wasmVM:            NewVMWrapper(wasmer),
 		accountKeeper:     accountKeeper,
 		bank:              NewBankCoinTransferrer(bankKeeper),

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -77,6 +77,7 @@ type Keeper struct {
 	bank                  CoinTransferrer
 	portKeeper            types.PortKeeper
 	capabilityKeeper      types.CapabilityKeeper
+	paramsKeeper          types.ParamsKeeper
 	wasmVM                types.WasmerEngine
 	wasmVMQueryHandler    WasmVMQueryHandler
 	wasmVMResponseHandler WasmVMResponseHandler
@@ -943,7 +944,10 @@ func (k Keeper) runtimeGasForContract(ctx sdk.Context) uint64 {
 	if meter.Limit() == 0 { // infinite gas meter with limit=0 and not out of gas
 		return math.MaxUint64
 	}
-	return k.gasRegister.ToWasmVMGas(meter.Limit() - meter.GasConsumedToLimit())
+	absoluteGasDiff := (meter.Limit() - meter.GasConsumedToLimit())
+	numerator, denominator := meter.Multiplier()
+	appliedAdjustmentGas := absoluteGasDiff * denominator / numerator
+	return k.gasRegister.ToWasmVMGas(appliedAdjustmentGas)
 }
 
 func (k Keeper) consumeRuntimeGas(ctx sdk.Context, gas uint64) {
@@ -1052,7 +1056,7 @@ func moduleLogger(ctx sdk.Context) log.Logger {
 
 // Querier creates a new grpc querier instance
 func Querier(k *Keeper) *grpcQuerier { //nolint:revive
-	return NewGrpcQuerier(k.cdc, k.storeKey, k, k.queryGasLimit)
+	return NewGrpcQuerier(k.cdc, k.storeKey, k, k.queryGasLimit, paramsKeeper)
 }
 
 // QueryGasLimit returns the gas limit for smart queries.

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -1056,7 +1056,7 @@ func moduleLogger(ctx sdk.Context) log.Logger {
 
 // Querier creates a new grpc querier instance
 func Querier(k *Keeper) *grpcQuerier { //nolint:revive
-	return NewGrpcQuerier(k.cdc, k.storeKey, k, k.queryGasLimit, paramsKeeper)
+	return NewGrpcQuerier(k.cdc, k.storeKey, k, k.queryGasLimit, k.paramsKeeper)
 }
 
 // QueryGasLimit returns the gas limit for smart queries.

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -84,7 +84,7 @@ func TestConstructorOptions(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			k := NewKeeper(nil, nil, paramtypes.NewSubspace(nil, nil, nil, nil, ""), authkeeper.AccountKeeper{}, nil, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, "tempDir", types.DefaultWasmConfig(), SupportedFeatures, spec.srcOpt)
+			k := NewKeeper(nil, nil, nil, paramtypes.NewSubspace(nil, nil, nil, nil, ""), authkeeper.AccountKeeper{}, nil, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, "tempDir", types.DefaultWasmConfig(), SupportedFeatures, spec.srcOpt)
 			spec.verify(t, k)
 		})
 	}

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -24,11 +24,12 @@ type grpcQuerier struct {
 	storeKey      sdk.StoreKey
 	keeper        types.ViewKeeper
 	queryGasLimit sdk.Gas
+	paramsKeeper  types.ParamsKeeper
 }
 
 // NewGrpcQuerier constructor
-func NewGrpcQuerier(cdc codec.Codec, storeKey sdk.StoreKey, keeper types.ViewKeeper, queryGasLimit sdk.Gas) *grpcQuerier { //nolint:revive
-	return &grpcQuerier{cdc: cdc, storeKey: storeKey, keeper: keeper, queryGasLimit: queryGasLimit}
+func NewGrpcQuerier(cdc codec.Codec, storeKey sdk.StoreKey, keeper types.ViewKeeper, queryGasLimit sdk.Gas, paramsKeeper types.ParamsKeeper) *grpcQuerier { //nolint:revive
+	return &grpcQuerier{cdc: cdc, storeKey: storeKey, keeper: keeper, queryGasLimit: queryGasLimit, paramsKeeper: paramsKeeper}
 }
 
 func (q grpcQuerier) ContractInfo(c context.Context, req *types.QueryContractInfoRequest) (*types.QueryContractInfoResponse, error) {
@@ -173,6 +174,8 @@ func (q grpcQuerier) SmartContractState(c context.Context, req *types.QuerySmart
 		return nil, err
 	}
 	ctx := sdk.UnwrapSDKContext(c)
+	// get params from store
+
 	ctx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, q.queryGasLimit))
 	// recover from out-of-gas panic
 	defer func() {

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -174,9 +174,10 @@ func (q grpcQuerier) SmartContractState(c context.Context, req *types.QuerySmart
 		return nil, err
 	}
 	ctx := sdk.UnwrapSDKContext(c)
-	// get params from store
-
-	ctx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, q.queryGasLimit))
+	// get cosmos gas params
+	gasParams := q.paramsKeeper.GetCosmosGasParams(ctx)
+	// set gas meter with appropriate multiplier
+	ctx = ctx.WithGasMeter(sdk.NewGasMeter(q.queryGasLimit, gasParams.CosmosGasMultiplierNumerator, gasParams.CosmosGasMultiplierDenominator))
 	// recover from out-of-gas panic
 	defer func() {
 		if r := recover(); r != nil {

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -184,6 +184,7 @@ func TestQuerySmartContractPanics(t *testing.T) {
 		},
 	}
 	for msg, spec := range specs {
+		ctx = ctx.WithGasMeter(sdk.NewGasMeterWithMultiplier(ctx, DefaultInstanceCost)).WithLogger(log.TestingLogger())
 		t.Run(msg, func(t *testing.T) {
 			keepers.WasmKeeper.wasmVM = &wasmtesting.MockWasmer{QueryFn: func(checksum wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error) {
 				spec.doInContract()

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -541,7 +541,7 @@ func TestQueryContractInfo(t *testing.T) {
 	govtypes.RegisterInterfaces(keepers.EncodingConfig.InterfaceRegistry)
 
 	k := keepers.WasmKeeper
-	querier := NewGrpcQuerier(k.cdc, k.storeKey, k, k.queryGasLimit)
+	querier := NewGrpcQuerier(k.cdc, k.storeKey, k, k.queryGasLimit, k.paramsKeeper)
 	myExtension := func(info *types.ContractInfo) {
 		// abuse gov proposal as a random protobuf extension with an Any type
 		myExt, err := govtypes.NewProposal(&govtypes.TextProposal{Title: "foo", Description: "bar"}, 1, anyDate, anyDate, false)

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -402,7 +402,7 @@ func createTestInput(
 	)
 	am.RegisterServices(module.NewConfigurator(appCodec, msgRouter, querier))
 	types.RegisterMsgServer(msgRouter, NewMsgServerImpl(NewDefaultPermissionKeeper(keeper)))
-	types.RegisterQueryServer(querier, NewGrpcQuerier(appCodec, keys[types.ModuleName], keeper, keeper.queryGasLimit))
+	types.RegisterQueryServer(querier, NewGrpcQuerier(appCodec, keys[types.ModuleName], keeper, keeper.queryGasLimit, keeper.paramsKeeper))
 
 	govRouter := govtypes.NewRouter().
 		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -374,6 +374,7 @@ func createTestInput(
 	keeper := NewKeeper(
 		appCodec,
 		keys[types.StoreKey],
+		paramsKeeper,
 		subspace(types.ModuleName),
 		accountKeeper,
 		bankKeeper,

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -402,7 +402,7 @@ func createTestInput(
 	)
 	am.RegisterServices(module.NewConfigurator(appCodec, msgRouter, querier))
 	types.RegisterMsgServer(msgRouter, NewMsgServerImpl(NewDefaultPermissionKeeper(keeper)))
-	types.RegisterQueryServer(querier, NewGrpcQuerier(appCodec, keys[types.ModuleName], keeper, keeper.queryGasLimit, keeper.paramsKeeper))
+	types.RegisterQueryServer(querier, NewGrpcQuerier(appCodec, keys[types.ModuleName], keeper, keeper.queryGasLimit, paramsKeeper))
 
 	govRouter := govtypes.NewRouter().
 		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).

--- a/x/wasm/types/expected_keepers.go
+++ b/x/wasm/types/expected_keepers.go
@@ -99,6 +99,10 @@ type CapabilityKeeper interface {
 	AuthenticateCapability(ctx sdk.Context, capability *capabilitytypes.Capability, name string) bool
 }
 
+type ParamsKeeper interface {
+	// TODO: add functions for gas multiplier
+}
+
 // ICS20TransferPortSource is a subset of the ibc transfer keeper.
 type ICS20TransferPortSource interface {
 	GetPort(ctx sdk.Context) string

--- a/x/wasm/types/expected_keepers.go
+++ b/x/wasm/types/expected_keepers.go
@@ -7,6 +7,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	connectiontypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
@@ -100,7 +101,7 @@ type CapabilityKeeper interface {
 }
 
 type ParamsKeeper interface {
-	// TODO: add functions for gas multiplier
+	GetCosmosGasParams(ctx sdk.Context) paramstypes.CosmosGasParams
 }
 
 // ICS20TransferPortSource is a subset of the ibc transfer keeper.


### PR DESCRIPTION
- Updates the Wasm gas meter limit to use new multiplier properly 
- Needed since certain expensive wasm executions were hitting the limit even though it still had available gas
- Verified on local chain + with heavy txs on atlantic-2