### PR TITLE
Update consume remaining gas to not panic w outOfGas

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -980,10 +980,6 @@ func (k Keeper) consumeRuntimeGas(ctx sdk.Context, gas uint64) {
 func (k Keeper) consumeRemainingGas(ctx sdk.Context) {
 	remainingGas := ctx.GasMeter().Limit() - ctx.GasMeter().GasConsumedToLimit()
 	ctx.GasMeter().ConsumeGas(remainingGas, "wasm contract")
-	// throw OutOfGas error if we ran out (got exactly to zero due to better limit enforcing)
-	if ctx.GasMeter().IsOutOfGas() {
-		panic(sdk.ErrorOutOfGas{Descriptor: "Wasmer function execution"})
-	}
 }
 
 // generates a contract address from codeID + instanceID


### PR DESCRIPTION
This allows us to consume the remaining gas but not raise the out of gas panic when there's exactly 0 remaining gas, since when consuming remaining gas, we get to exactly 0 remaining gas anyways. With this change, true query errors will still propagate despite the gas being used.