### PR TITLE
Make wasmd snapshot use SC instead of SS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ replace (
 	// Use the cosmos-flavored keyring library
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => ../sei-cosmos
+	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.26
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ replace (
 	// Use the cosmos-flavored keyring library
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
-	github.com/cosmos/cosmos-sdk => github.com/sei-protocol/sei-cosmos v0.3.19
+	github.com/cosmos/cosmos-sdk => ../sei-cosmos
 	github.com/cosmos/iavl => github.com/sei-protocol/sei-iavl v0.1.9
 	github.com/cosmos/ibc-go/v3 => github.com/sei-protocol/sei-ibc-go/v3 v3.1.0
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.

--- a/go.sum
+++ b/go.sum
@@ -772,6 +772,8 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
+github.com/sei-protocol/sei-cosmos v0.3.26 h1:brYESCnbYI7gr/O8QEHxIyntZrIZp4ONA7m0xfDn6eI=
+github.com/sei-protocol/sei-cosmos v0.3.26/go.mod h1:og/KbejR/zSQ8otapODEDU9zYNhFSUDbq9+tgeYePyU=
 github.com/sei-protocol/sei-db v0.0.27-0.20240123064153-d6dfa112e760 h1:MiHIPwPH2Yo6LQQfINgFTofm+K1EqpQYmg8h5m/cFrs=
 github.com/sei-protocol/sei-db v0.0.27-0.20240123064153-d6dfa112e760/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,6 @@ github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8 h1:ajJQhvqPSQFJJ4aV5mDAM
 github.com/savaki/jq v0.0.0-20161209013833-0e6baecebbf8/go.mod h1:Nw/CCOXNyF5JDd6UpYxBwG5WWZ2FOJ/d5QnXL4KQ6vY=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sei-protocol/sei-cosmos v0.3.19 h1:EQZ+i0virWhmE6XY4w9Dc4tYhVOdZos6Gl9qU39eMGU=
-github.com/sei-protocol/sei-cosmos v0.3.19/go.mod h1:rWb90yP2YTqF3CxcdcMvxHYsdLihTNMA5wZi7FwtaeI=
 github.com/sei-protocol/sei-db v0.0.27-0.20240123064153-d6dfa112e760 h1:MiHIPwPH2Yo6LQQfINgFTofm+K1EqpQYmg8h5m/cFrs=
 github.com/sei-protocol/sei-db v0.0.27-0.20240123064153-d6dfa112e760/go.mod h1:F/ZKZA8HJPcUzSZPA8yt6pfwlGriJ4RDR4eHKSGLStI=
 github.com/sei-protocol/sei-iavl v0.1.9 h1:y4mVYftxLNRs6533zl7N0/Ch+CzRQc04JDfHolIxgBE=

--- a/x/wasm/keeper/snapshotter.go
+++ b/x/wasm/keeper/snapshotter.go
@@ -48,7 +48,7 @@ func (ws *WasmSnapshotter) SupportedFormats() []uint32 {
 }
 
 func (ws *WasmSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) error {
-	cacheMS, err := ws.cms.CacheMultiStoreWithVersion(int64(height))
+	cacheMS, err := ws.cms.CacheMultiStoreForExport(int64(height))
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (ws *WasmSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) e
 
 		return false
 	})
-
+	cacheMS.Close()
 	return rerr
 }
 

--- a/x/wasm/keeper/snapshotter.go
+++ b/x/wasm/keeper/snapshotter.go
@@ -52,6 +52,7 @@ func (ws *WasmSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) e
 	if err != nil {
 		return err
 	}
+	defer cacheMS.Close()
 
 	ctx := sdk.NewContext(cacheMS, tmproto.Header{}, false, log.NewNopLogger())
 	seenBefore := make(map[string]bool)
@@ -87,7 +88,6 @@ func (ws *WasmSnapshotter) Snapshot(height uint64, protoWriter protoio.Writer) e
 
 		return false
 	})
-	cacheMS.Close()
 	return rerr
 }
 

--- a/x/wasm/keeper/wasmtesting/store.go
+++ b/x/wasm/keeper/wasmtesting/store.go
@@ -21,6 +21,9 @@ type mockCMS struct {
 	committed *bool
 }
 
+func (m *mockCMS) Close() {
+}
+
 func (m *mockCMS) Write() {
 	*m.committed = true
 }


### PR DESCRIPTION
This PR is added with https://github.com/sei-protocol/sei-cosmos/pull/523 to make sure that we are calling a different function to access cacheMultiStore which is backed by SC, not SS when seidb is enabled.