### PR TITLE
Add CW call depth

### DIFF
--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -123,3 +123,9 @@ func WithMaxQueryStackSize(m uint32) Option {
 		k.maxQueryStackSize = m
 	})
 }
+
+func WithMaxCallDepth(m uint32) Option {
+	return optsFn(func(k *Keeper) {
+		k.maxCallDepth = m
+	})
+}

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -28,7 +28,9 @@ func TestConstructorOptions(t *testing.T) {
 		"message handler": {
 			srcOpt: WithMessageHandler(&wasmtesting.MockMessageHandler{}),
 			verify: func(t *testing.T, k Keeper) {
-				assert.IsType(t, &wasmtesting.MockMessageHandler{}, k.messenger)
+				require.IsType(t, callDepthMessageHandler{}, k.messenger)
+				messenger, _ := k.messenger.(callDepthMessageHandler)
+				assert.IsType(t, &wasmtesting.MockMessageHandler{}, messenger.Messenger)
 			},
 		},
 		"query plugins": {
@@ -43,7 +45,9 @@ func TestConstructorOptions(t *testing.T) {
 				return &wasmtesting.MockMessageHandler{}
 			}),
 			verify: func(t *testing.T, k Keeper) {
-				assert.IsType(t, &wasmtesting.MockMessageHandler{}, k.messenger)
+				require.IsType(t, callDepthMessageHandler{}, k.messenger)
+				messenger, _ := k.messenger.(callDepthMessageHandler)
+				assert.IsType(t, &wasmtesting.MockMessageHandler{}, messenger.Messenger)
 			},
 		},
 		"query plugins decorator": {
@@ -75,10 +79,16 @@ func TestConstructorOptions(t *testing.T) {
 				assert.Equal(t, uint64(2), costCanonical)
 			},
 		},
-		"max recursion query limit": {
+		"max query recursion limit": {
 			srcOpt: WithMaxQueryStackSize(1),
 			verify: func(t *testing.T, k Keeper) {
 				assert.IsType(t, uint32(1), k.maxQueryStackSize)
+			},
+		},
+		"max message recursion limit": {
+			srcOpt: WithMaxCallDepth(1),
+			verify: func(t *testing.T, k Keeper) {
+				assert.IsType(t, uint32(1), k.maxCallDepth)
 			},
 		},
 	}

--- a/x/wasm/types/errors.go
+++ b/x/wasm/types/errors.go
@@ -87,6 +87,11 @@ var (
 
 	// ErrExceedMaxQueryStackSize error if max query stack size is exceeded
 	ErrExceedMaxQueryStackSize = sdkErrors.Register(DefaultCodespace, 27, "max query stack size exceeded")
+
+	// unused 28..29
+
+	// ErrExceedMaxCallDepth error if max query stack size is exceeded
+	ErrExceedMaxCallDepth = sdkErrors.Register(DefaultCodespace, 30, "max call depth exceeded")
 )
 
 type ErrNoSuchContract struct {

--- a/x/wasm/types/wasmer_engine.go
+++ b/x/wasm/types/wasmer_engine.go
@@ -9,6 +9,8 @@ import (
 // DefaultMaxQueryStackSize maximum size of the stack of contract instances doing queries
 const DefaultMaxQueryStackSize uint32 = 10
 
+const DefaultMaxCallDepth uint32 = 500
+
 // WasmerEngine defines the WASM contract runtime engine.
 type WasmerEngine interface {
 	// Create will compile the wasm code, and store the resulting pre-compile


### PR DESCRIPTION
This implements a similar change to the advisory patch released by the CW team for capping call depth:
https://github.com/CosmWasm/wasmd/commit/71cf6a8145426b82ed6249ecc86ddd281af9f97b